### PR TITLE
Owned, and also annoying

### DIFF
--- a/b.rb
+++ b/b.rb
@@ -35,7 +35,7 @@ end
 
 
 
-def reformat_languages(langs)
+def rl(langs)
   new_hash = {}
   langs.each do |k,v|
     v.collect do |language, type|
@@ -56,8 +56,3 @@ def reformat_languages(langs)
      new_hash
     
 end
-
-
-
-
-


### PR DESCRIPTION
Well I was right. I needed to move ahead to the lab after this one complete it and come back to eviscerate this lab. SO here is what I was doing incorrectly:

```
new_hash.collect do |k,v|
      if new_hash[k] == :ruby || new_hash[k] == :java || new_hash[k] == :python
        new_hash[v][:style] = [:oo]
      elsif new_hash[k] == :javascript
        new_hash[v][:style] = [:oo, :functional]
      elsif new_hash[k] == :clojure || new_hash[k] == :erlang || new_hash[k] == :scala
      new_hash[v][:style] = [:functional] 
```

Every time I was typing out **new_hash[argument]** I was messing up. This is what the correctly functioning code looks like: 

```
def reformat_languages(langs)
  new_hash = {}
  langs.each do |k,v|
    v.collect do |language, type|
      new_hash[language] = type

    end
  end
    new_hash.collect do |k,v|
      if k == :ruby || k == :java || k == :python
        v[:style] = [:oo] # adding to the v variable hash the new key :style and the accompanying value [:oo]
      elsif k == :javascript
        v[:style] = [:oo, :functional]
      elsif k == :clojure || k == :erlang || k == :scala
      v[:style] = [:functional]          

      end
     end
     new_hash

end
```

I noticed from the Bachelor lab that the deeper iterations didn't need the big "parent" hash accompanying them in order to move their data around and manipulate it like here:

```
def get_occupation(data, hometown)
  array = []
  data.each do |season, contestants|
    contestants.each do |con_data|
      if con_data["hometown"] == hometown
       array << con_data["occupation"] # right here
      end
    end
  end
  array.first
end
```

Notice **con_data["occupation"]** being passed into the `array` variable. I'm using that data without paying "homage" to the larger `data` hash. So, in short I learned that when operating on pieces of information while abstracting you don't have to include all the levels of iteration. That and how to add to a hash.
